### PR TITLE
fix: resourcesPath in AdGuard converter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const $errorsAdguard = document.querySelector("#errors-adguard");
 const $errorsAbp = document.querySelector("#errors-abp");
 
 const ADGUARD_CONVERTER_OPTIONS = {
-  resourcesPath: "/web_accessible_resources",
+  resourcesPath: "/rule_resources/redirects",
 };
 
 $submitButton.addEventListener("click", async (ev) => {


### PR DESCRIPTION
We added an ability to push custom options but the proper options was not being passed.

refs https://github.com/ghostery/ghostery-extension/blob/0e53156400f2f5f55f9654d55b0a2242de0bbce2/extension-manifest-v3/scripts/build.js#L173