### PR TITLE
Remove wrapping slashes from regexps

### DIFF
--- a/src/converters/helpers.js
+++ b/src/converters/helpers.js
@@ -143,12 +143,10 @@ export function normalizeRule(rule, { resourcesMapping = DEFAULT_RESOURCE_MAPPIN
   if (
     newRule.condition &&
     newRule.condition.regexFilter &&
-    !(
-      newRule.condition.regexFilter.startsWith("/") &&
-      newRule.condition.regexFilter.endsWith("/")
-    )
+    newRule.condition.regexFilter.startsWith("/") &&
+    newRule.condition.regexFilter.endsWith("/")
   ) {
-    newRule.condition.regexFilter = `/${newRule.condition.regexFilter}/`;
+    newRule.condition.regexFilter = newRule.condition.regexFilter.slice(1,-1)
   }
 
   if (newRule.condition && newRule.condition.excludedDomains) {

--- a/test/unit/converters/adguard.spec.js
+++ b/test/unit/converters/adguard.spec.js
@@ -19,22 +19,22 @@ describe('adguard converter', () => {
   });
 
   // to be fixed with https://github.com/AdguardTeam/tsurlfilter/pull/109
-  it.skip("/baynote(-observer)?([0-9]+)\.js/", async () => {
-    const { rules } = await convertWithAdguard(['/baynote(-observer)?([0-9]+)\.js/']);
+  it("/baynote(-observer)?([0-9]+)\.js/", async () => {
+    const { rules } = await convertWithAdguard([String.raw`/baynote(-observer)?([0-9]+)\.js/`]);
     expect(rules[0]).toEqual({
       action: {
         type: "block"
       },
       condition: {
         isUrlFilterCaseSensitive: false,
-        regexFilter: "/baynote(-observer)?([0-9]+)\.js/"
+        regexFilter: String.raw`baynote(-observer)?([0-9]+)\.js`
       },
       id: 1,
       priority: 1
     });
   });
 
-  it.skip("handles regexp with ?", async () => {
+  it("handles regexp with ?", async () => {
     const { rules } = await convertWithAdguard(['/a?/']);
     expect(rules[0]).toEqual({
       action: {
@@ -42,10 +42,28 @@ describe('adguard converter', () => {
       },
       condition: {
         isUrlFilterCaseSensitive: false,
-        regexFilter: "/a?/"
+        regexFilter: "a?"
       },
       id: 1,
       priority: 1
+    });
+  });
+
+  it("handles regexp escaping", async () => {
+    const { rules } = await convertWithAdguard([String.raw`/\\d/$doc`]);
+    expect(rules[0]).toEqual({
+      action: {
+        type: "block"
+      },
+      condition: {
+        isUrlFilterCaseSensitive: false,
+        regexFilter: String.raw`\\d`,
+        resourceTypes: [
+          "main_frame"
+        ]
+      },
+      id: 1,
+      priority: 101
     });
   });
 });

--- a/test/unit/converters/helpers.spec.js
+++ b/test/unit/converters/helpers.spec.js
@@ -86,14 +86,14 @@ describe('normalizeRule', () => {
     })
   })
 
-  it('wraps regex rules in //', () => {
+  it('does not wraps regex rules in //', () => {
     expect(normalizeRule({
       condition: {
         regexFilter: 'test',
       },
     })).toEqual({
       condition: {
-        regexFilter: '/test/',
+        regexFilter: 'test',
       },
     });
   });


### PR DESCRIPTION
Wrapping slashes are tolerated by the browsers but fail with additional syntax being used. Ones that we can confirm are `^` and `$` for example: 
* `/\.com\/[_0-9a-zA-Z]+\.jpg$/`
