### PR TITLE
Support regexps

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,4 +17,15 @@ export default [
       },
     },
   },
+  {
+    files: ['./src/page/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+      },
+      parserOptions: {
+        ecmaVersion: 'latest',
+      },
+    },
+  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "license": "GPL-3.0",
       "dependencies": {
+        "@adguard/re2-wasm": "^1.2.0",
         "@adguard/scriptlets": "^2.2.7",
         "@adguard/tsurlfilter": "^3.4.0",
         "@eyeo/webext-ad-filtering-solution": "^1.23.1"
@@ -72,7 +73,6 @@
       "resolved": "https://registry.npmjs.org/@adguard/re2-wasm/-/re2-wasm-1.2.0.tgz",
       "integrity": "sha512-yMtEJfThxN9rEYm2Zg3X8jUKaPYq5wByc90JbMspSWJo7MXw664gTvLD7/wijl6y79VSuAs77bXUIgBXutMp7A==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prerelease": "npm run build"
   },
   "dependencies": {
+    "@adguard/re2-wasm": "^1.2.0",
     "@adguard/scriptlets": "^2.2.7",
     "@adguard/tsurlfilter": "^3.4.0",
     "@eyeo/webext-ad-filtering-solution": "^1.23.1"

--- a/scripts/page/helpers/build.js
+++ b/scripts/page/helpers/build.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import * as esbuild from 'esbuild';
 
-import { SOURCE_PATH, DIST_PATH } from './paths.js';
+import { SOURCE_PATH, DIST_PATH, ROOT_PATH } from './paths.js';
 
 function logBuildError(result) {
   if (!result.errors.length) {
@@ -23,6 +23,18 @@ export default async function build({ debug = false } = {}) {
     path.join(DIST_PATH, 'index.html'),
   );
 
+  // Copy re2.wasm to the output directory
+  fs.copyFileSync(
+    path.join(ROOT_PATH, 'node_modules', '@adguard', 're2-wasm', 'build', 'wasm', 're2.wasm'),
+    path.join(DIST_PATH, 're2.wasm'),
+  );
+
+  // Copy re2.js to the output directory
+  fs.copyFileSync(
+    path.join(ROOT_PATH, 'node_modules', '@adguard', 're2-wasm', 'build', 'wasm', 're2.js'),
+    path.join(DIST_PATH, 're2.js'),
+  );
+
   const result = await esbuild.build({
     entryPoints: [path.join(SOURCE_PATH, 'page', 'index.js')],
     outdir: DIST_PATH,
@@ -32,6 +44,7 @@ export default async function build({ debug = false } = {}) {
     format: 'esm',
     target: ['es2020'],
     platform: 'browser',
+    external: ['fs', 'path'],
   });
 
   logBuildError(result);

--- a/scripts/page/serve.js
+++ b/scripts/page/serve.js
@@ -19,6 +19,7 @@ const MIME_TYPES = {
   '.gif': 'image/gif',
   '.svg': 'image/svg+xml',
   '.ico': 'image/x-icon',
+  '.wasm': 'application/wasm',
 };
 
 await bundle();

--- a/src/converters/adguard.ts
+++ b/src/converters/adguard.ts
@@ -1,6 +1,56 @@
+// Add type declaration for globalThis.chrome
+declare global {
+  var chrome: {
+    runtime: {
+      lastError: null;
+    };
+    declarativeNetRequest: {
+      isRegexSupported: (regexOptions: { regex: string; flags: string }, callback: (result: { isSupported: boolean }) => void) => void;
+    };
+  };
+}
+
 import { DeclarativeFilterConverter, Filter } from '@adguard/tsurlfilter/es/declarative-converter';
 import { FilterListPreprocessor } from '@adguard/tsurlfilter';
 import { normalizeFilter, normalizeRule } from './helpers.js';
+
+/**
+ * Maximum memory in bytes for the regex.
+ * This value is lower than 2MB as required by chrome, but it was determined empirically.
+ */
+const MAX_MEMORY_BYTES = 1990;
+
+if (typeof globalThis.chrome === 'undefined') {
+  globalThis.chrome = {};
+}
+
+if (typeof globalThis.chrome.runtime === 'undefined') {
+  globalThis.chrome.runtime = {
+    lastError: null,
+  };
+}
+
+if (typeof globalThis.chrome.declarativeNetRequest === 'undefined') {
+  globalThis.chrome.declarativeNetRequest = {
+    isRegexSupported: async (regexOptions: { regex: string, flags: string }, callback: (result: { isSupported: boolean }) => void) => {
+      try {
+        let RE2Class;
+        if (typeof process !== 'undefined' && process.versions && process.versions.node) {
+          // Node.js: dynamic import
+          const mod = await import('@adguard/re2-wasm');
+          RE2Class = mod.RE2;
+        } else {
+          RE2Class = window.RE2;
+        }
+        new RE2Class(regexOptions.regex, `u${regexOptions.flags}`, MAX_MEMORY_BYTES);
+        callback({ isSupported: true });
+      } catch (e) {
+        console.error(e);
+        callback({ isSupported: false });
+      }
+    },
+  };
+}
 
 const converter = new DeclarativeFilterConverter();
 
@@ -17,6 +67,7 @@ const createFilter = (rules: string[], filterId = 0) => {
 export default async function convert(rules: string[], { resourcesPath = '/prefix' }: { resourcesPath?: string } = {}) {
   const filter = createFilter(rules.map((rule) => normalizeFilter(rule) ?? ''));
   const conversionResult = await converter.convertStaticRuleSet(filter, { resourcesPath });
+
   const declarativeRules = await conversionResult.ruleSet.getDeclarativeRules();
 
   return {

--- a/src/converters/adguard.ts
+++ b/src/converters/adguard.ts
@@ -67,7 +67,6 @@ const createFilter = (rules: string[], filterId = 0) => {
 export default async function convert(rules: string[], { resourcesPath = '/prefix' }: { resourcesPath?: string } = {}) {
   const filter = createFilter(rules.map((rule) => normalizeFilter(rule) ?? ''));
   const conversionResult = await converter.convertStaticRuleSet(filter, { resourcesPath });
-
   const declarativeRules = await conversionResult.ruleSet.getDeclarativeRules();
 
   return {

--- a/src/page/index.js
+++ b/src/page/index.js
@@ -1,4 +1,6 @@
+/* global window, document */
 import { convertWithAdguard, convertWithAbp } from '../index.js';
+import { isReadyPromise } from './re2-loader.js';
 
 const $input = document.querySelector('#input textarea');
 const $submitButton = document.querySelector('#input input[type=submit]');
@@ -35,6 +37,8 @@ window.addEventListener('message', async (event) => {
   const { converter, filters } = event.data;
 
   let rules, errors;
+
+  await isReadyPromise;
 
   try {
     if (converter === 'adguard') {

--- a/src/page/index.js
+++ b/src/page/index.js
@@ -1,4 +1,3 @@
-/* global window, document */
 import { convertWithAdguard, convertWithAbp } from '../index.js';
 import { isReadyPromise } from './re2-loader.js';
 

--- a/src/page/re2-class.js
+++ b/src/page/re2-class.js
@@ -1,0 +1,173 @@
+/**
+ * Copied from https://github.com/AdguardTeam/re2-wasm/blob/main/src/re2.ts
+ * Before calling new RE2, ensure that window.Module.WrappedRE2 is present
+ */
+
+function escapeRegExp(pattern) {
+  return pattern.replace(/(^|[^\\])((?:\\\\)*)\//g, '$1$2\\/');
+}
+
+const ALPHA_UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const HEX = '0123456789ABCDEF';
+
+function isHexadecimal(char) {
+  return HEX.indexOf(char.toUpperCase()) !== -1;
+}
+
+function translateRegExp(pattern, multiline) {
+  const result = [];
+  if (pattern === '') {
+    return '(?:)';
+  } else if (multiline) {
+    result.push('(?m)');
+  }
+  for (let i = 0; i < pattern.length; ) {
+    if (pattern[i] === '\\') {
+      if (i + 1 < pattern.length) {
+        switch (pattern[i + 1]) {
+          case '\\':
+            // Consume "\\", output "\\"
+            result.push('\\\\');
+            i += 2;
+            break;
+          case 'c':
+            if (i + 2 < pattern.length) {
+              const alphaIndex = ALPHA_UPPER.indexOf(pattern[i + 2]) + 1;
+              if (alphaIndex >= 0) {
+                // Consume "\c[upper case character]", output "\x[hex digit][hex digit]"
+                result.push('\\x', HEX[Math.floor(alphaIndex / 16)], HEX[alphaIndex % 16]);
+                i += 3;
+                break;
+              }
+            }
+            // Consume "\c", output "\c"
+            result.push('\\c');
+            i += 2;
+            break;
+          case 'u':
+            if (i + 2 < pattern.length) {
+              const ch2 = pattern[i + 2];
+              if (isHexadecimal(ch2)) {
+                // Consume "\u[hex digit]", output "\x{[hex digit]"
+                result.push('\\x{');
+                result.push(ch2);
+                i += 3;
+                // Consume and output up to 3 more hex digits
+                for (
+                  let j = 0;
+                  j < 3 && i < pattern.length && isHexadecimal(pattern[i]);
+                  i++, j++
+                ) {
+                  result.push(pattern[i]);
+                }
+                // Output "}"
+                result.push('}');
+                break;
+              } else if (ch2 === '{') {
+                // Consume "\u" followed by "{", output "\x"
+                // The default case handles the subsequent characters
+                result.push('\\x');
+                i += 2;
+                break;
+              }
+            }
+            // Consume and output "\u"
+            result.push('\\u');
+            i += 2;
+            break;
+          default:
+            // Consume and output "\[char]"
+            result.push('\\', pattern[i + 1]);
+            i += 2;
+        }
+        continue;
+      }
+    } else if (pattern[i] === '/') {
+      // Consume "/"" and output "\/"
+      // An existing "\/" would have been handled by the above default case
+      result.push('\\/');
+      i += 1;
+      continue;
+    } else if (pattern.substring(i, i + 3) === '(?<') {
+      if (pattern[i + 3] !== '=' && pattern[i + 3] !== '!') {
+        // Consume "(?<" and output "(?P<"
+        result.push('(?P<');
+        i += 3;
+        continue;
+      }
+    }
+    // Consume and output the next character
+    result.push(pattern[i]);
+    i += 1;
+  }
+  return result.join('');
+}
+
+export class RE2 {
+  constructor(pattern, flags, maxMem) {
+    this._global = false;
+    this._ignoreCase = false;
+    this._multiline = false;
+    this._dotAll = false;
+    this._unicode = false;
+    this._sticky = false;
+    this.pattern = '(?:)';
+    if (typeof pattern !== 'string') {
+      if (pattern instanceof RegExp) {
+        flags = flags ?? pattern.flags;
+        pattern = pattern.source;
+      } else {
+        if (pattern === undefined) {
+          pattern = '(?:)';
+        } else {
+          pattern = pattern + '';
+        }
+      }
+    }
+    if (pattern === '') {
+      pattern = '(?:)';
+    }
+    pattern = escapeRegExp(pattern);
+    flags = flags ?? '';
+    for (const flag of flags) {
+      switch (flag) {
+        case 'g':
+          this._global = true;
+          break;
+        case 'i':
+          this._ignoreCase = true;
+          break;
+        case 'm':
+          this._multiline = true;
+          break;
+        case 's':
+          this._dotAll = true;
+          break;
+        case 'u':
+          this._unicode = true;
+          break;
+        case 'y':
+          this._sticky = true;
+          break;
+      }
+    }
+    if (!this._unicode) {
+      throw new Error(
+        'RE2 only works in unicode mode. The "u" flag must be passed when constructing a RE2 instance',
+      );
+    }
+    this.pattern = pattern;
+    this.wrapper = new window.Module.WrappedRE2(
+      translateRegExp(pattern, this._multiline),
+      this._ignoreCase,
+      this._multiline,
+      this._dotAll,
+      maxMem ?? 0,
+    );
+    if (!this.wrapper.ok()) {
+      throw new SyntaxError(
+        `Invalid regular expression: /${pattern}/${flags}: ${this.wrapper.error()}`,
+      );
+    }
+  }
+}

--- a/src/page/re2-loader.js
+++ b/src/page/re2-loader.js
@@ -1,6 +1,5 @@
 import { RE2 } from './re2-class.js';
 
-// Make RE2 available via global
 window.RE2 = RE2;
 
 let readyResolver;

--- a/src/page/re2-loader.js
+++ b/src/page/re2-loader.js
@@ -48,7 +48,6 @@ async function initializeRE2() {
   }
 }
 
-// Initialize RE2
 initializeRE2();
 
 /**

--- a/src/page/re2-loader.js
+++ b/src/page/re2-loader.js
@@ -1,0 +1,225 @@
+/* global window, document, fetch, console */
+
+let readyResolver;
+const isReadyPromise = new Promise((resolve) => {
+  readyResolver = resolve;
+});
+
+export { isReadyPromise };
+
+// Preload WASM and initialize Module
+async function initializeRE2() {
+  try {
+    // First, fetch the WASM file
+    const response = await fetch('./re2.wasm');
+    const wasmBinary = await response.arrayBuffer();
+
+    // Set up Module configuration
+    window.Module = {
+      wasmBinary,
+      locateFile: (path, prefix) => {
+        if (path.endsWith('.wasm')) {
+          return './re2.wasm';
+        }
+        return prefix + path;
+      },
+      onAbort: (what) => {
+        console.error('WASM loading aborted:', what);
+      },
+      onRuntimeInitialized: () => {
+        console.log('RE2 WASM module loaded successfully');
+        readyResolver();
+      },
+      printErr: (text) => {
+        console.error(text);
+      },
+      print: (text) => {
+        console.log(text);
+      },
+    };
+
+    // Now load re2.js
+    const script = document.createElement('script');
+    script.src = './re2.js';
+    script.onerror = (error) => {
+      console.error('Failed to load re2.js:', error);
+    };
+    document.head.appendChild(script);
+  } catch (error) {
+    console.error('Failed to initialize RE2:', error);
+  }
+}
+
+// Initialize RE2
+initializeRE2();
+
+function escapeRegExp(pattern) {
+  return pattern.replace(/(^|[^\\])((?:\\\\)*)\//g, '$1$2\\/');
+}
+
+const ALPHA_UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const HEX = '0123456789ABCDEF';
+
+function isHexadecimal(char) {
+  return HEX.indexOf(char.toUpperCase()) !== -1;
+}
+
+function translateRegExp(pattern, multiline) {
+  const result = [];
+  if (pattern === '') {
+    return '(?:)';
+  } else if (multiline) {
+    result.push('(?m)');
+  }
+  for (let i = 0; i < pattern.length; ) {
+    if (pattern[i] === '\\') {
+      if (i + 1 < pattern.length) {
+        switch (pattern[i + 1]) {
+          case '\\':
+            // Consume "\\", output "\\"
+            result.push('\\\\');
+            i += 2;
+            break;
+          case 'c':
+            if (i + 2 < pattern.length) {
+              const alphaIndex = ALPHA_UPPER.indexOf(pattern[i + 2]) + 1;
+              if (alphaIndex >= 0) {
+                // Consume "\c[upper case character]", output "\x[hex digit][hex digit]"
+                result.push('\\x', HEX[Math.floor(alphaIndex / 16)], HEX[alphaIndex % 16]);
+                i += 3;
+                break;
+              }
+            }
+            // Consume "\c", output "\c"
+            result.push('\\c');
+            i += 2;
+            break;
+          case 'u':
+            if (i + 2 < pattern.length) {
+              const ch2 = pattern[i + 2];
+              if (isHexadecimal(ch2)) {
+                // Consume "\u[hex digit]", output "\x{[hex digit]"
+                result.push('\\x{');
+                result.push(ch2);
+                i += 3;
+                // Consume and output up to 3 more hex digits
+                for (
+                  let j = 0;
+                  j < 3 && i < pattern.length && isHexadecimal(pattern[i]);
+                  i++, j++
+                ) {
+                  result.push(pattern[i]);
+                }
+                // Output "}"
+                result.push('}');
+                break;
+              } else if (ch2 === '{') {
+                // Consume "\u" followed by "{", output "\x"
+                // The default case handles the subsequent characters
+                result.push('\\x');
+                i += 2;
+                break;
+              }
+            }
+            // Consume and output "\u"
+            result.push('\\u');
+            i += 2;
+            break;
+          default:
+            // Consume and output "\[char]"
+            result.push('\\', pattern[i + 1]);
+            i += 2;
+        }
+        continue;
+      }
+    } else if (pattern[i] === '/') {
+      // Consume "/"" and output "\/"
+      // An existing "\/" would have been handled by the above default case
+      result.push('\\/');
+      i += 1;
+      continue;
+    } else if (pattern.substring(i, i + 3) === '(?<') {
+      if (pattern[i + 3] !== '=' && pattern[i + 3] !== '!') {
+        // Consume "(?<" and output "(?P<"
+        result.push('(?P<');
+        i += 3;
+        continue;
+      }
+    }
+    // Consume and output the next character
+    result.push(pattern[i]);
+    i += 1;
+  }
+  return result.join('');
+}
+
+class RE2 {
+  constructor(pattern, flags, maxMem) {
+    this._global = false;
+    this._ignoreCase = false;
+    this._multiline = false;
+    this._dotAll = false;
+    this._unicode = false;
+    this._sticky = false;
+    this.pattern = '(?:)';
+    if (typeof pattern !== 'string') {
+      if (pattern instanceof RegExp) {
+        flags = flags ?? pattern.flags;
+        pattern = pattern.source;
+      } else {
+        if (pattern === undefined) {
+          pattern = '(?:)';
+        } else {
+          pattern = pattern + '';
+        }
+      }
+    }
+    if (pattern === '') {
+      pattern = '(?:)';
+    }
+    pattern = escapeRegExp(pattern);
+    flags = flags ?? '';
+    for (const flag of flags) {
+      switch (flag) {
+        case 'g':
+          this._global = true;
+          break;
+        case 'i':
+          this._ignoreCase = true;
+          break;
+        case 'm':
+          this._multiline = true;
+          break;
+        case 's':
+          this._dotAll = true;
+          break;
+        case 'u':
+          this._unicode = true;
+          break;
+        case 'y':
+          this._sticky = true;
+          break;
+      }
+    }
+    if (!this._unicode) {
+      throw new Error(
+        'RE2 only works in unicode mode. The "u" flag must be passed when constructing a RE2 instance',
+      );
+    }
+    this.pattern = pattern;
+    this.wrapper = new window.Module.WrappedRE2(
+      translateRegExp(pattern, this._multiline),
+      this._ignoreCase,
+      this._multiline,
+      this._dotAll,
+      maxMem ?? 0,
+    );
+    if (!this.wrapper.ok()) {
+      throw new SyntaxError(
+        `Invalid regular expression: /${pattern}/${flags}: ${this.wrapper.error()}`,
+      );
+    }
+  }
+}
+
+window.RE2 = RE2;

--- a/src/page/re2-loader.js
+++ b/src/page/re2-loader.js
@@ -1,3 +1,8 @@
+import { RE2 } from './re2-class.js';
+
+// Make RE2 available via global
+window.RE2 = RE2;
+
 let readyResolver;
 const isReadyPromise = new Promise((resolve) => {
   readyResolver = resolve;
@@ -5,14 +10,11 @@ const isReadyPromise = new Promise((resolve) => {
 
 export { isReadyPromise };
 
-// Preload WASM and initialize Module
 async function initializeRE2() {
   try {
-    // First, fetch the WASM file
     const response = await fetch('./re2.wasm');
     const wasmBinary = await response.arrayBuffer();
 
-    // Set up Module configuration
     window.Module = {
       wasmBinary,
       locateFile: (path, prefix) => {
@@ -25,6 +27,7 @@ async function initializeRE2() {
         console.error('WASM loading aborted:', what);
       },
       onRuntimeInitialized: () => {
+        // from now window.module.WrappedRE2 is available
         console.log('RE2 WASM module loaded successfully');
         readyResolver();
       },
@@ -36,7 +39,6 @@ async function initializeRE2() {
       },
     };
 
-    // Now load re2.js
     const script = document.createElement('script');
     script.src = './re2.js';
     script.onerror = (error) => {
@@ -49,178 +51,3 @@ async function initializeRE2() {
 }
 
 initializeRE2();
-
-/**
- * Copied from https://github.com/AdguardTeam/re2-wasm/blob/main/src/re2.ts
- */
-
-function escapeRegExp(pattern) {
-  return pattern.replace(/(^|[^\\])((?:\\\\)*)\//g, '$1$2\\/');
-}
-
-const ALPHA_UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-const HEX = '0123456789ABCDEF';
-
-function isHexadecimal(char) {
-  return HEX.indexOf(char.toUpperCase()) !== -1;
-}
-
-function translateRegExp(pattern, multiline) {
-  const result = [];
-  if (pattern === '') {
-    return '(?:)';
-  } else if (multiline) {
-    result.push('(?m)');
-  }
-  for (let i = 0; i < pattern.length; ) {
-    if (pattern[i] === '\\') {
-      if (i + 1 < pattern.length) {
-        switch (pattern[i + 1]) {
-          case '\\':
-            // Consume "\\", output "\\"
-            result.push('\\\\');
-            i += 2;
-            break;
-          case 'c':
-            if (i + 2 < pattern.length) {
-              const alphaIndex = ALPHA_UPPER.indexOf(pattern[i + 2]) + 1;
-              if (alphaIndex >= 0) {
-                // Consume "\c[upper case character]", output "\x[hex digit][hex digit]"
-                result.push('\\x', HEX[Math.floor(alphaIndex / 16)], HEX[alphaIndex % 16]);
-                i += 3;
-                break;
-              }
-            }
-            // Consume "\c", output "\c"
-            result.push('\\c');
-            i += 2;
-            break;
-          case 'u':
-            if (i + 2 < pattern.length) {
-              const ch2 = pattern[i + 2];
-              if (isHexadecimal(ch2)) {
-                // Consume "\u[hex digit]", output "\x{[hex digit]"
-                result.push('\\x{');
-                result.push(ch2);
-                i += 3;
-                // Consume and output up to 3 more hex digits
-                for (
-                  let j = 0;
-                  j < 3 && i < pattern.length && isHexadecimal(pattern[i]);
-                  i++, j++
-                ) {
-                  result.push(pattern[i]);
-                }
-                // Output "}"
-                result.push('}');
-                break;
-              } else if (ch2 === '{') {
-                // Consume "\u" followed by "{", output "\x"
-                // The default case handles the subsequent characters
-                result.push('\\x');
-                i += 2;
-                break;
-              }
-            }
-            // Consume and output "\u"
-            result.push('\\u');
-            i += 2;
-            break;
-          default:
-            // Consume and output "\[char]"
-            result.push('\\', pattern[i + 1]);
-            i += 2;
-        }
-        continue;
-      }
-    } else if (pattern[i] === '/') {
-      // Consume "/"" and output "\/"
-      // An existing "\/" would have been handled by the above default case
-      result.push('\\/');
-      i += 1;
-      continue;
-    } else if (pattern.substring(i, i + 3) === '(?<') {
-      if (pattern[i + 3] !== '=' && pattern[i + 3] !== '!') {
-        // Consume "(?<" and output "(?P<"
-        result.push('(?P<');
-        i += 3;
-        continue;
-      }
-    }
-    // Consume and output the next character
-    result.push(pattern[i]);
-    i += 1;
-  }
-  return result.join('');
-}
-
-class RE2 {
-  constructor(pattern, flags, maxMem) {
-    this._global = false;
-    this._ignoreCase = false;
-    this._multiline = false;
-    this._dotAll = false;
-    this._unicode = false;
-    this._sticky = false;
-    this.pattern = '(?:)';
-    if (typeof pattern !== 'string') {
-      if (pattern instanceof RegExp) {
-        flags = flags ?? pattern.flags;
-        pattern = pattern.source;
-      } else {
-        if (pattern === undefined) {
-          pattern = '(?:)';
-        } else {
-          pattern = pattern + '';
-        }
-      }
-    }
-    if (pattern === '') {
-      pattern = '(?:)';
-    }
-    pattern = escapeRegExp(pattern);
-    flags = flags ?? '';
-    for (const flag of flags) {
-      switch (flag) {
-        case 'g':
-          this._global = true;
-          break;
-        case 'i':
-          this._ignoreCase = true;
-          break;
-        case 'm':
-          this._multiline = true;
-          break;
-        case 's':
-          this._dotAll = true;
-          break;
-        case 'u':
-          this._unicode = true;
-          break;
-        case 'y':
-          this._sticky = true;
-          break;
-      }
-    }
-    if (!this._unicode) {
-      throw new Error(
-        'RE2 only works in unicode mode. The "u" flag must be passed when constructing a RE2 instance',
-      );
-    }
-    this.pattern = pattern;
-    this.wrapper = new window.Module.WrappedRE2(
-      translateRegExp(pattern, this._multiline),
-      this._ignoreCase,
-      this._multiline,
-      this._dotAll,
-      maxMem ?? 0,
-    );
-    if (!this.wrapper.ok()) {
-      throw new SyntaxError(
-        `Invalid regular expression: /${pattern}/${flags}: ${this.wrapper.error()}`,
-      );
-    }
-  }
-}
-
-window.RE2 = RE2;

--- a/src/page/re2-loader.js
+++ b/src/page/re2-loader.js
@@ -51,6 +51,10 @@ async function initializeRE2() {
 // Initialize RE2
 initializeRE2();
 
+/**
+ * Copied from https://github.com/AdguardTeam/re2-wasm/blob/main/src/re2.ts
+ */
+
 function escapeRegExp(pattern) {
   return pattern.replace(/(^|[^\\])((?:\\\\)*)\//g, '$1$2\\/');
 }

--- a/src/page/re2-loader.js
+++ b/src/page/re2-loader.js
@@ -1,5 +1,3 @@
-/* global window, document, fetch, console */
-
 let readyResolver;
 const isReadyPromise = new Promise((resolve) => {
   readyResolver = resolve;

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -6,5 +6,6 @@ describe('converters', () => {
   it('generate same rules', async () => {
     await testRule('||domain.com');
     await testRule('@@||domain.com');
+    await testRule(String.raw`/.*domain.com/`);
   });
 });


### PR DESCRIPTION
AdGuard converter is designed to be used within webextension. Only when run by a CLI it is using RE2 (regexp engine used by Chrome internals).

For nodejs and browser usecases we have to provide RE2 as `chrome.declarativeNetRequest.isRegexpSupported` polyfill.