### PR TITLE
ci(internal): follow label scheme per adblocker

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -7,31 +7,67 @@
   "email": "ghostery-adblocker-bot@users.noreply.github.com",
   "labels": [
     {
-      "name": "major",
-      "changelogTitle": "💥 Breaking Change",
-      "description": "Increment the major version when merged",
+      "name": "PR: Breaking Change :boom:",
+      "description": "Increment major version when merged",
+      "changelogTitle": ":boom: Breaking Change",
+      "releaseType": "major",
       "overwrite": true,
-      "releaseType": "major"
+      "color": "#e2372b"
     },
     {
-      "name": "minor",
-      "changelogTitle": "🚀 Enhancement",
-      "description": "Increment the minor version when merged",
+      "name": "PR: New Feature :rocket:",
+      "description": "Increment minor version when merged",
+      "changelogTitle": ":rocket: New Feature",
+      "releaseType": "minor",
       "overwrite": true,
-      "releaseType": "minor"
+      "color": "#2e449b"
     },
     {
-      "name": "patch",
-      "changelogTitle": "🐛 Bug Fix",
-      "description": "Increment the patch version when merged",
+      "name": "PR: Performance :running_woman:",
+      "description": "Increment minor version when merged",
+      "changelogTitle": ":running_woman: Performance",
+      "releaseType": "minor",
       "overwrite": true,
-      "releaseType": "patch"
+      "color": "#ead99f"
+    },
+    {
+      "name": "PR: Bug Fix :bug:",
+      "description": "Increment patch version when merged",
+      "changelogTitle": ":bug: Bug Fix",
+      "releaseType": "patch",
+      "overwrite": true,
+      "color": "#56dd97"
+    },
+    {
+      "name": "PR: Polish :nail_care:",
+      "description": "Increment patch version when merged",
+      "changelogTitle": ":nail_care: Polish",
+      "releaseType": "patch",
+      "overwrite": true,
+      "color": "#a9bbe8"
+    },
+    {
+      "name": "PR: Internal :house:",
+      "description": "Changes only affect internals",
+      "changelogTitle": ":house: Internal",
+      "releaseType": "none",
+      "overwrite": true,
+      "color": "#5b1482"
+    },
+    {
+      "name": "PR: Docs :memo:",
+      "description": "Changes only affect documentation",
+      "changelogTitle": ":memo: Documentation",
+      "releaseType": "none",
+      "overwrite": true,
+      "color": "#d2f28a"
     },
     {
       "name": "skip-release",
       "description": "Preserve the current version when merged",
+      "releaseType": "skip",
       "overwrite": true,
-      "releaseType": "skip"
+      "color": "#e069cf"
     },
     {
       "name": "PR: Dependencies :nut_and_bolt:",


### PR DESCRIPTION
If we have labels of `major`, `minor`, and `patch`, dependabot tries to attach it to the dependency update pulls. It's problematic as our `auto` setup conflicts with this scheme.

Thus we need to bring scheme from `adblocker` repository then try to use it instead. Corresponding labels need to be created as well.

refs https://github.com/ghostery/adblocker/blob/ecc86043088d873d01d260882d3e85ed611fa3e2/package.json
refs https://github.com/dependabot/dependabot-core/commit/fb3d263054ecf4bf0602968f4c3526453c1fbe98#diff-71cd3b7b870c1616c8d6[…]cbdc22d3eb85d2057R165-R169