### PR TITLE
feat: add direct adguard export for better tree-shaking

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 24.1.0
+nodejs 24.3.0

--- a/package.json
+++ b/package.json
@@ -19,6 +19,16 @@
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
       }
+    },
+    "./adguard": {
+      "import": {
+        "types": "./dist/esm/converters/adguard.d.ts",
+        "default": "./dist/esm/converters/adguard.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/converters/adguard.d.ts",
+        "default": "./dist/commonjs/converters/adguard.js"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
This is non-breaking change, which allows better tree-shaking of the adguard converter used by the extension.