### PR TITLE
fix(exports): use export pattern for better tree-shaking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,2 @@
-import convertWithAdguard from './converters/adguard.js';
-import convertWithAbp from './converters/abp.js';
-
-export { convertWithAdguard, convertWithAbp };
+export { default as convertWithAdguard } from './converters/adguard.js';
+export { default as convertWithAbp } from './converters/abp.js';


### PR DESCRIPTION
When importing and re-exporting, the bundlers might not tree-shake properly. This PR updates how we export converters.